### PR TITLE
Handle channel group positions

### DIFF
--- a/pvr.demo/PVRDemoAddonSettings.xml
+++ b/pvr.demo/PVRDemoAddonSettings.xml
@@ -201,6 +201,7 @@
     <group>
       <name>Demo Group #1</name>
       <radio>0</radio>
+      <position>1</position>
       <members>
         <member>1</member>
         <member>2</member>
@@ -218,6 +219,7 @@
     <group>
       <name>Demo Group #2</name>
       <radio>0</radio>
+      <position>3</position>
       <members>
         <member>1</member>
         <member>3</member>
@@ -225,6 +227,18 @@
         <member>7</member>
         <member>9</member>
         <member>11</member>
+      </members>
+    </group>
+    <group>
+      <name>Demo Group #3</name>
+      <radio>0</radio>
+      <position>2</position>
+      <members>
+        <member>4</member>
+        <member>5</member>
+        <member>6</member>
+        <member>7</member>
+        <member>8</member>
       </members>
     </group>
   </channelgroups>

--- a/pvr.demo/addon.xml
+++ b/pvr.demo/addon.xml
@@ -6,7 +6,7 @@
   provider-name="Pulse-Eight Ltd.">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.5"/>
+    <import addon="xbmc.pvr" version="1.9.6"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/src/PVRDemoData.cpp
+++ b/src/PVRDemoData.cpp
@@ -136,6 +136,9 @@ bool PVRDemoData::LoadDemoData(void)
 
       /* radio/TV */
       XMLUtils::GetBoolean(pGroupNode, "radio", group.bRadio);
+      
+      /* sort position */
+      XMLUtils::GetInt(pGroupNode, "position", group.iPosition);
 
       /* members */
       TiXmlNode* pMembers = pGroupNode->FirstChild("members");
@@ -491,6 +494,7 @@ PVR_ERROR PVRDemoData::GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
       memset(&xbmcGroup, 0, sizeof(PVR_CHANNEL_GROUP));
 
       xbmcGroup.bIsRadio = bRadio;
+      xbmcGroup.iPosition = group.iPosition;
       strncpy(xbmcGroup.strGroupName, group.strGroupName.c_str(), sizeof(xbmcGroup.strGroupName) - 1);
 
       PVR->TransferChannelGroup(handle, &xbmcGroup);

--- a/src/PVRDemoData.h
+++ b/src/PVRDemoData.h
@@ -89,6 +89,7 @@ struct PVRDemoChannelGroup
   bool             bRadio;
   int              iGroupId;
   std::string      strGroupName;
+  int              iPosition;
   std::vector<int> members;
 };
 


### PR DESCRIPTION
This adds the handling of channel group sorting by specifing a position in the PVRDemoAddonSettings.xml

@ksooo or @Jalle19 mind taking a look.