### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.demo/addon.xml
+++ b/pvr.demo/addon.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.demo"
-  version="1.10.5"
+  version="1.11.0"
   name="PVR Demo Client"
   provider-name="Pulse-Eight Ltd.">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/src/PVRDemoData.cpp
+++ b/src/PVRDemoData.cpp
@@ -630,6 +630,9 @@ PVR_ERROR PVRDemoData::GetTimers(ADDON_HANDLE handle)
     PVR_TIMER xbmcTimer;
     memset(&xbmcTimer, 0, sizeof(PVR_TIMER));
 
+    /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+    xbmcTimer.iTimerType = PVR_TIMER_TYPE_NONE;
+
     xbmcTimer.iClientIndex      = ++i;
     xbmcTimer.iClientChannelUid = timer.iChannelId;
     xbmcTimer.startTime         = timer.startTime;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -309,6 +309,12 @@ PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted)
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+{
+  /* TODO: Implement this to get support for the timer features introduced with PVR API 1.9.7 */
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 int GetTimersAmount(void)
 {
   if (m_data)
@@ -322,6 +328,7 @@ PVR_ERROR GetTimers(ADDON_HANDLE handle)
   if (m_data)
     return m_data->GetTimers(handle);
 
+  /* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
@@ -353,7 +360,7 @@ PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int las
 int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording) { return -1; }
 PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*) { return PVR_ERROR_NOT_IMPLEMENTED; };
 PVR_ERROR AddTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool /*bDeleteScheduled*/) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR UpdateTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxAbort(void) {}
 DemuxPacket* DemuxRead(void) { return NULL; }


### PR DESCRIPTION
For, J**** PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J**** and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.