### PR TITLE
Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.demo/addon.xml.in
+++ b/pvr.demo/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.demo"
-  version="1.11.5"
+  version="1.11.6"
   name="PVR Demo Client"
   provider-name="Pulse-Eight Ltd.">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/src/PVRDemoData.cpp
+++ b/src/PVRDemoData.cpp
@@ -566,7 +566,8 @@ PVR_ERROR PVRDemoData::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &
         tag.strIconPath        = myTag.strIconPath.c_str();
         tag.iGenreType         = myTag.iGenreType;
         tag.iGenreSubType      = myTag.iGenreSubType;
-
+        tag.iFlags             = EPG_TAG_FLAG_UNDEFINED;
+        
         iLastEndTimeTmp = tag.endTime;
 
         PVR->TransferEpgEntry(handle, &tag);


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075