### PR TITLE
Update to libp8-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,14 @@ enable_language(CXX)
 
 find_package(kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
-find_package(platform REQUIRED)
+find_package(p8-platform REQUIRED)
 
 include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${platform_INCLUDE_DIRS}
+                    ${p8-platform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR})
 
 set(DEPLIBS ${kodiplatform_LIBRARIES}
-            ${platform_LIBRARIES})
+            ${p8-platform_LIBRARIES})
 
 set(PVRDEMO_SOURCES src/client.cpp
                     src/PVRDemoData.cpp)

--- a/src/PVRDemoData.h
+++ b/src/PVRDemoData.h
@@ -21,7 +21,7 @@
  */
 
 #include <vector>
-#include "platform/util/StdString.h"
+#include "p8-platform/util/StdString.h"
 #include "client.h"
 
 struct PVRDemoEpgEntry

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -23,7 +23,7 @@
 #include "kodi/xbmc_pvr_dll.h"
 #include "kodi/libKODI_guilib.h"
 #include "PVRDemoData.h"
-#include <platform/util/util.h>
+#include <p8-platform/util/util.h>
 
 using namespace std;
 using namespace ADDON;


### PR DESCRIPTION
Do not merge this! Needs libp8-platform-dev packaging first and it's missing add-on bump.
Also, currently untested.