### PR TITLE
Add season, episode and subtitle support for recordings.

### DIFF
--- a/pvr.demo/PVRDemoAddonSettings.xml
+++ b/pvr.demo/PVRDemoAddonSettings.xml
@@ -280,6 +280,8 @@
       <icon></icon>
       <genretype>16</genretype>
       <genresubtype>0</genresubtype>
+      <season>10</season>
+      <episode>5</episode>
     </entry>
     <entry>
       <broadcastid>200</broadcastid>
@@ -292,6 +294,8 @@
       <icon></icon>
       <genretype>32</genretype>
       <genresubtype>0</genresubtype>
+      <season>10</season>
+      <episode>6</episode>
     </entry>
     <entry>
       <broadcastid>300</broadcastid>
@@ -304,6 +308,7 @@
       <icon></icon>
       <genretype>48</genretype>
       <genresubtype>0</genresubtype>
+      <episode>3</episode>
     </entry>
     <entry>
       <broadcastid>400</broadcastid>
@@ -316,6 +321,7 @@
       <icon></icon>
       <genretype>64</genretype>
       <genresubtype>0</genresubtype>
+      <episode>4</episode>
     </entry>
     <entry>
       <broadcastid>500</broadcastid>
@@ -525,38 +531,66 @@
   </epg>
   <recordings>
     <recording>
-      <title>Demo Recording entry 1</title>
+      <title>Demo Recording entry A</title>
+      <episodename>SubEpisodeA32</episodename>
       <url></url>
       <directory>/Directory1/SubDirectory1/</directory>
       <channelname>Demo TV Channel 1</channelname>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
-      <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</plot>
+      <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac.</plot>
       <genretype>10</genretype>
       <genresubtype>0</genresubtype>
+      <season>3</season>
+      <episode>2</episode>
       <time>12:00</time>
       <duration>7200</duration>
     </recording>
     <recording>
-      <title>Demo Recording entry 2</title>
+      <!-- Deliberately have same title so we can see any grouping by series-->
+      <title>Demo Recording entry A</title>
+      <episodename>SubEpisodeA31</episodename>
       <url></url>
       <directory>/Directory1/SubDirectory1/</directory>
       <channelname>Demo TV Channel 2</channelname>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
-      <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</plot>
+      <plot>Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero.</plot>
       <genretype>10</genretype>
       <genresubtype>0</genresubtype>
+      <!-- Deliberately have an earlier episode shown at a later time to check sorting -->
+      <season>3</season>
+      <episode>1</episode>
       <time>14:00</time>
       <duration>7500</duration>
     </recording>
     <recording>
+      <!-- Deliberately have same title so we can see any grouping by series-->
+      <title>Demo Recording entry A</title>
+      <!-- Deliberately no sub-title/episode name -->
+      <url></url>
+      <directory>/Directory1/SubDirectory1/</directory>
+      <channelname>Demo TV Channel 2</channelname>
+      <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
+      <plot>Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero.</plot>
+      <genretype>10</genretype>
+      <genresubtype>0</genresubtype>
+      <!-- Deliberately have duplicate season/episode -->
+      <season>3</season>
+      <episode>1</episode>
+      <time>18:00</time>
+      <duration>7500</duration>
+    </recording>
+    <recording>
       <title>Demo Recording entry 3</title>
+      <episodename>SubEpisode3_4</episodename>
       <url></url>
       <directory>/Directory1/SubDirectory1/</directory>
       <channelname>Demo TV Channel 3</channelname>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
-      <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</plot>
+      <plot>Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum.</plot>
       <genretype>10</genretype>
       <genresubtype>0</genresubtype>
+      <!-- Deliberately have no season since mythtv can parse just episode -->
+      <episode>4</episode>
       <time>20:00</time>
       <duration>7500</duration>
     </recording>
@@ -569,6 +603,9 @@
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</plot>
       <genretype>10</genretype>
       <genresubtype>0</genresubtype>
+      <!-- Season 0 is used for specials -->
+      <season>0</season>
+      <episode>4</episode>
       <time>18:00</time>
       <duration>7500</duration>
     </recording>

--- a/src/PVRDemoData.cpp
+++ b/src/PVRDemoData.cpp
@@ -208,6 +208,12 @@ bool PVRDemoData::LoadDemoData(void)
       /* genre subtype */
       XMLUtils::GetInt(pEpgNode, "genresubtype", entry.iGenreSubType);
 
+      if (!XMLUtils::GetInt(pEpgNode, "season", entry.iSeriesNumber))
+        entry.iSeriesNumber = -1;
+
+      if (!XMLUtils::GetInt(pEpgNode, "episode", entry.iEpisodeNumber))
+       entry.iEpisodeNumber = -1;
+
       XBMC->Log(LOG_DEBUG, "loaded EPG entry '%s' channel '%d' start '%d' end '%d'", entry.strTitle.c_str(), entry.iChannelId, entry.startTime, entry.endTime);
       channel.epg.push_back(entry);
     }
@@ -228,6 +234,10 @@ bool PVRDemoData::LoadDemoData(void)
       if (!XMLUtils::GetString(pRecordingNode, "title", strTmp))
         continue;
       recording.strTitle = strTmp;
+
+      /* episode name (sub-title)*/
+      if (XMLUtils::GetString(pRecordingNode, "episodename", strTmp))
+        recording.strEpisodeName = strTmp;
 
       /* recording url */
       if (!XMLUtils::GetString(pRecordingNode, "url", strTmp))
@@ -260,6 +270,12 @@ bool PVRDemoData::LoadDemoData(void)
 
       /* genre subtype */
       XMLUtils::GetInt(pRecordingNode, "genresubtype", recording.iGenreSubType);
+
+      if (!XMLUtils::GetInt(pRecordingNode, "season", recording.iSeriesNumber))
+        recording.iSeriesNumber = -1;
+
+      if (!XMLUtils::GetInt(pRecordingNode, "episode", recording.iEpisodeNumber))
+        recording.iEpisodeNumber = -1;
 
       /* duration */
       XMLUtils::GetInt(pRecordingNode, "duration", recording.iDuration);
@@ -566,6 +582,8 @@ PVR_ERROR PVRDemoData::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &
         tag.strIconPath        = myTag.strIconPath.c_str();
         tag.iGenreType         = myTag.iGenreType;
         tag.iGenreSubType      = myTag.iGenreSubType;
+        tag.iSeriesNumber      = myTag.iSeriesNumber;
+        tag.iEpisodeNumber     = myTag.iEpisodeNumber;
         tag.iFlags             = EPG_TAG_FLAG_UNDEFINED;
         
         iLastEndTimeTmp = tag.endTime;
@@ -595,10 +613,13 @@ PVR_ERROR PVRDemoData::GetRecordings(ADDON_HANDLE handle, bool bDeleted)
     PVRDemoRecording &recording = *it;
 
     PVR_RECORDING xbmcRecording;
+    memset(&xbmcRecording, 0, sizeof(PVR_RECORDING));
 
     xbmcRecording.iDuration     = recording.iDuration;
     xbmcRecording.iGenreType    = recording.iGenreType;
     xbmcRecording.iGenreSubType = recording.iGenreSubType;
+    xbmcRecording.iSeriesNumber = recording.iSeriesNumber;
+    xbmcRecording.iEpisodeNumber= recording.iEpisodeNumber;
     xbmcRecording.recordingTime = recording.recordingTime;
     xbmcRecording.bIsDeleted      = bDeleted;
 
@@ -607,6 +628,7 @@ PVR_ERROR PVRDemoData::GetRecordings(ADDON_HANDLE handle, bool bDeleted)
     strncpy(xbmcRecording.strPlot,        recording.strPlot.c_str(),        sizeof(xbmcRecording.strPlot) - 1);
     strncpy(xbmcRecording.strRecordingId, recording.strRecordingId.c_str(), sizeof(xbmcRecording.strRecordingId) - 1);
     strncpy(xbmcRecording.strTitle,       recording.strTitle.c_str(),       sizeof(xbmcRecording.strTitle) - 1);
+    strncpy(xbmcRecording.strEpisodeName, recording.strEpisodeName.c_str(), sizeof(xbmcRecording.strEpisodeName) - 1);
     strncpy(xbmcRecording.strStreamURL,   recording.strStreamURL.c_str(),   sizeof(xbmcRecording.strStreamURL) - 1);
     strncpy(xbmcRecording.strDirectory,   recording.strDirectory.c_str(),   sizeof(xbmcRecording.strDirectory) - 1);
 

--- a/src/PVRDemoData.h
+++ b/src/PVRDemoData.h
@@ -40,8 +40,8 @@ struct PVRDemoEpgEntry
 //  int         iParentalRating;
 //  int         iStarRating;
 //  bool        bNotify;
-//  int         iSeriesNumber;
-//  int         iEpisodeNumber;
+  int         iSeriesNumber;
+  int         iEpisodeNumber;
 //  int         iEpisodePartNumber;
 //  std::string strEpisodeName;
 };
@@ -70,8 +70,11 @@ struct PVRDemoRecording
   std::string strRecordingId;
   std::string strStreamURL;
   std::string strTitle;
+  std::string strEpisodeName;
   std::string strDirectory;
   time_t      recordingTime;
+  int         iSeriesNumber;
+  int         iEpisodeNumber;
 };
 
 struct PVRDemoTimer


### PR DESCRIPTION
This change adds basic support for season, episode and subtitle inside the xml file for recordings.

This is useful for skin development when the developer's backend doesn't provide this information, but the skin developer wants to check it will work correctly with a pvr backend that does provide the information.

I also updated some of the recording entries to have the same series name for checking sorting in the GUI.

Also zero-out the PVR_RECORDING to avoid data from stack/a previous entry being used and this makes it consistent with the other transferred data.
