### PR TITLE
Change to Add-on API 2 library type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
+set(USE_KODI_API_LEVEL 2)
+
 find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
@@ -15,7 +17,8 @@ include_directories(${kodiplatform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR})
 
 set(DEPLIBS ${kodiplatform_LIBRARIES}
-            ${p8-platform_LIBRARIES})
+            ${p8-platform_LIBRARIES}
+            ${kodi-addon-sharedlibrary_LIBRARIES})
 
 set(PVRDEMO_SOURCES src/client.cpp
                     src/PVRDemoData.cpp)

--- a/pvr.demo/addon.xml.in
+++ b/pvr.demo/addon.xml.in
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.demo"
-  version="2.4.0"
+  version="2.5.0"
   name="PVR Demo Client"
   provider-name="Pulse-Eight Ltd.">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="5.2.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/src/PVRDemoData.cpp
+++ b/src/PVRDemoData.cpp
@@ -21,9 +21,12 @@
 
 #include "util/XMLUtils.h"
 #include "PVRDemoData.h"
+#include "client.h"
+
+#include <kodi/api2/AddonLib.hpp>
+#include <kodi/api2/pvr/Transfer.hpp>
 
 using namespace std;
-using namespace ADDON;
 
 PVRDemoData::PVRDemoData(void)
 {
@@ -58,14 +61,14 @@ bool PVRDemoData::LoadDemoData(void)
 
   if (!xmlDoc.LoadFile(strSettingsFile))
   {
-    XBMC->Log(LOG_ERROR, "invalid demo data (no/invalid data file found at '%s')", strSettingsFile.c_str());
+    KodiAPI::Log(ADDON_LOG_ERROR, "invalid demo data (no/invalid data file found at '%s')", strSettingsFile.c_str());
     return false;
   }
 
   TiXmlElement *pRootElement = xmlDoc.RootElement();
   if (strcmp(pRootElement->Value(), "demo") != 0)
   {
-    XBMC->Log(LOG_ERROR, "invalid demo data (no <demo> tag found)");
+    KodiAPI::Log(ADDON_LOG_ERROR, "invalid demo data (no <demo> tag found)");
     return false;
   }
 
@@ -208,7 +211,7 @@ bool PVRDemoData::LoadDemoData(void)
       /* genre subtype */
       XMLUtils::GetInt(pEpgNode, "genresubtype", entry.iGenreSubType);
 
-      XBMC->Log(LOG_DEBUG, "loaded EPG entry '%s' channel '%d' start '%d' end '%d'", entry.strTitle.c_str(), entry.iChannelId, entry.startTime, entry.endTime);
+      KodiAPI::Log(ADDON_LOG_DEBUG, "loaded EPG entry '%s' channel '%d' start '%d' end '%d'", entry.strTitle.c_str(), entry.iChannelId, entry.startTime, entry.endTime);
       channel.epg.push_back(entry);
     }
   }
@@ -421,7 +424,7 @@ bool PVRDemoData::LoadDemoData(void)
         }
       }
 
-      XBMC->Log(LOG_DEBUG, "loaded timer '%s' channel '%d' start '%d' end '%d'", timer.strTitle.c_str(), timer.iChannelId, timer.startTime, timer.endTime);
+      KodiAPI::Log(ADDON_LOG_DEBUG, "loaded timer '%s' channel '%d' start '%d' end '%d'", timer.strTitle.c_str(), timer.iChannelId, timer.startTime, timer.endTime);
       m_timers.push_back(timer);
     }
   }
@@ -454,7 +457,7 @@ PVR_ERROR PVRDemoData::GetChannels(ADDON_HANDLE handle, bool bRadio)
       strncpy(xbmcChannel.strIconPath, channel.strIconPath.c_str(), sizeof(xbmcChannel.strIconPath) - 1);
       xbmcChannel.bIsHidden         = false;
 
-      PVR->TransferChannelEntry(handle, &xbmcChannel);
+      KodiAPI::PVR::Transfer::ChannelEntry(handle, &xbmcChannel);
     }
   }
 
@@ -503,7 +506,7 @@ PVR_ERROR PVRDemoData::GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
       xbmcGroup.iPosition = group.iPosition;
       strncpy(xbmcGroup.strGroupName, group.strGroupName.c_str(), sizeof(xbmcGroup.strGroupName) - 1);
 
-      PVR->TransferChannelGroup(handle, &xbmcGroup);
+      KodiAPI::PVR::Transfer::ChannelGroup(handle, &xbmcGroup);
     }
   }
 
@@ -530,7 +533,7 @@ PVR_ERROR PVRDemoData::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHA
         xbmcGroupMember.iChannelUniqueId  = channel.iUniqueId;
         xbmcGroupMember.iChannelNumber    = channel.iChannelNumber;
 
-        PVR->TransferChannelGroupMember(handle, &xbmcGroupMember);
+        KodiAPI::PVR::Transfer::ChannelGroupMember(handle, &xbmcGroupMember);
       }
     }
   }
@@ -576,7 +579,7 @@ PVR_ERROR PVRDemoData::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &
         
         iLastEndTimeTmp = tag.endTime;
 
-        PVR->TransferEpgEntry(handle, &tag);
+        KodiAPI::PVR::Transfer::EpgEntry(handle, &tag);
       }
 
       iLastEndTime = iLastEndTimeTmp;
@@ -620,7 +623,7 @@ PVR_ERROR PVRDemoData::GetRecordings(ADDON_HANDLE handle, bool bDeleted)
     /* TODO: PVR API 5.0.0: Implement this */
     xbmcRecording.iChannelUid = PVR_CHANNEL_INVALID_UID;
 
-    PVR->TransferRecordingEntry(handle, &xbmcRecording);
+    KodiAPI::PVR::Transfer::RecordingEntry(handle, &xbmcRecording);
   }
 
   return PVR_ERROR_NO_ERROR;
@@ -653,7 +656,7 @@ PVR_ERROR PVRDemoData::GetTimers(ADDON_HANDLE handle)
     strncpy(xbmcTimer.strTitle, timer.strTitle.c_str(), sizeof(timer.strTitle) - 1);
     strncpy(xbmcTimer.strSummary, timer.strSummary.c_str(), sizeof(timer.strSummary) - 1);
 
-    PVR->TransferTimerEntry(handle, &xbmcTimer);
+    KodiAPI::PVR::Transfer::TimerEntry(handle, &xbmcTimer);
   }
 
   return PVR_ERROR_NO_ERROR;

--- a/src/PVRDemoData.h
+++ b/src/PVRDemoData.h
@@ -22,7 +22,7 @@
 
 #include <vector>
 #include "p8-platform/util/StdString.h"
-#include "client.h"
+#include <kodi/api2/pvr/General.hpp>
 
 struct PVRDemoEpgEntry
 {

--- a/src/client.h
+++ b/src/client.h
@@ -20,11 +20,8 @@
  *
  */
 
-#include "libXBMC_addon.h"
-#include "libXBMC_pvr.h"
+#include <string>
 
-extern bool                          m_bCreated;
-extern std::string                   g_strUserPath;
-extern std::string                   g_strClientPath;
-extern ADDON::CHelper_libXBMC_addon *XBMC;
-extern CHelper_libXBMC_pvr          *PVR;
+extern bool        m_bCreated;
+extern std::string g_strUserPath;
+extern std::string g_strClientPath;


### PR DESCRIPTION
This are the changes for the add-on to use API level 2 system.

The rework for Kodi is visible here: https://github.com/xbmc/xbmc/pull/9368

Add-on tested here on Linux and works OK.
