### PR TITLE
implement strEpisodeName, iSeriesNumber, iEpisodeNumber

### DIFF
--- a/pvr.demo/PVRDemoAddonSettings.xml
+++ b/pvr.demo/PVRDemoAddonSettings.xml
@@ -277,6 +277,9 @@
       <end>7200</end>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed. </plot>
+      <series>1</series>
+      <episode>1</episode>
+      <episodetitle>Demo EPG entry 1 Episode Title</episodetitle>
       <icon></icon>
       <genretype>16</genretype>
       <genresubtype>0</genresubtype>
@@ -289,6 +292,8 @@
       <end>7200</end>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed. </plot>
+      <episode>2</episode>
+      <episodetitle>Demo EPG entry 2 Episode Title</episodetitle>
       <icon></icon>
       <genretype>32</genretype>
       <genresubtype>0</genresubtype>
@@ -301,6 +306,7 @@
       <end>7200</end>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed. </plot>
+      <episodetitle>Demo EPG entry 3 Episode Title</episodetitle>
       <icon></icon>
       <genretype>48</genretype>
       <genresubtype>0</genresubtype>
@@ -313,6 +319,8 @@
       <end>7200</end>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed. </plot>
+      <series>0</series>
+      <episode>1</episode>
       <icon></icon>
       <genretype>64</genretype>
       <genresubtype>0</genresubtype>

--- a/pvr.demo/addon.xml.in
+++ b/pvr.demo/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.demo"
-  version="3.3.0"
+  version="3.4.0"
   name="PVR Demo Client"
   provider-name="Pulse-Eight Ltd.">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/PVRDemoData.cpp
+++ b/src/PVRDemoData.cpp
@@ -199,6 +199,15 @@ bool PVRDemoData::LoadDemoData(void)
       if (XMLUtils::GetString(pEpgNode, "plotoutline", strTmp))
         entry.strPlotOutline = strTmp;
 
+      if (!XMLUtils::GetInt(pEpgNode, "series", entry.iSeriesNumber))
+        entry.iSeriesNumber = 0;
+
+      if (!XMLUtils::GetInt(pEpgNode, "episode", entry.iEpisodeNumber))
+        entry.iEpisodeNumber = 0;
+
+      if (XMLUtils::GetString(pEpgNode, "episodetitle", strTmp))
+        entry.strEpisodeName = strTmp;
+
       /* icon path */
       if (XMLUtils::GetString(pEpgNode, "icon", strTmp))
         entry.strIconPath = strTmp;
@@ -571,7 +580,10 @@ PVR_ERROR PVRDemoData::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &
         tag.iGenreType         = myTag.iGenreType;
         tag.iGenreSubType      = myTag.iGenreSubType;
         tag.iFlags             = EPG_TAG_FLAG_UNDEFINED;
-        
+        tag.iSeriesNumber      = myTag.iSeriesNumber;
+        tag.iEpisodeNumber     = myTag.iEpisodeNumber;;
+        tag.strEpisodeName     = myTag.strEpisodeName.c_str();
+
         iLastEndTimeTmp = tag.endTime;
 
         PVR->TransferEpgEntry(handle, &tag);

--- a/src/PVRDemoData.h
+++ b/src/PVRDemoData.h
@@ -40,10 +40,10 @@ struct PVRDemoEpgEntry
 //  int         iParentalRating;
 //  int         iStarRating;
 //  bool        bNotify;
-//  int         iSeriesNumber;
-//  int         iEpisodeNumber;
+  int         iSeriesNumber;
+  int         iEpisodeNumber;
 //  int         iEpisodePartNumber;
-//  std::string strEpisodeName;
+  std::string strEpisodeName;
 };
 
 struct PVRDemoChannel


### PR DESCRIPTION
Ive done this to be able to demonstrate a skinning issue i have with estuary. 
If there is an episode/season number (doesnt have to be both), but no episode title, the EPG guide display will show "S 1 EP 1 :". The : gets shown regardless.

I dont know anything about the skinning side of Kodi, so i was going to throw this up as an issue with the test case to see if it can be made correct or not. 