### PR TITLE
Implement series/episode/eptitle for recordings

### DIFF
--- a/pvr.demo/PVRDemoAddonSettings.xml
+++ b/pvr.demo/PVRDemoAddonSettings.xml
@@ -535,6 +535,7 @@
     <!-- TV Recordings -->
     <recording>
       <title>Demo TV Recording entry 1</title>
+      <episodetitle>Demo TV Recording 1 Episode Name</episodetitle>
       <url>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</url>
       <directory>/Directory1/SubDirectory1/</directory>
       <channelname>Demo TV Channel 1</channelname>
@@ -545,9 +546,12 @@
       <time>12:00</time>
       <duration>7200</duration>
       <radio>0</radio>
+      <series>2</series>
+      <episode>1</episode>
     </recording>
     <recording>
       <title>Demo TV Recording entry 2</title>
+      <episodetitle>Demo TV Recording 2 Episode Name</episodetitle>
       <url>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</url>
       <directory>/Directory1/SubDirectory1/</directory>
       <channelname>Demo TV Channel 2</channelname>
@@ -558,12 +562,14 @@
       <time>14:00</time>
       <duration>7500</duration>
       <radio>0</radio>
+      <episode>3</episode>
     </recording>
     <recording>
       <title>Demo TV Recording entry 3</title>
       <url>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</url>
       <directory>/Directory1/SubDirectory1/</directory>
       <channelname>Demo TV Channel 3</channelname>
+      <episodetitle>Demo TV Recording 3 Episode Name</episodetitle>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</plot>
       <genretype>10</genretype>
@@ -802,10 +808,13 @@
       <url></url>
       <directory>/Directory1/SubDirectory1/</directory>
       <channelname>Demo TV Channel 1</channelname>
+      <episodetitle>Demo TV Recording entry 11 Episode Name</episodetitle>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</plot>
       <genretype>10</genretype>
       <genresubtype>0</genresubtype>
+      <series>1</series>
+      <episode>2</episode>
       <time>12:00</time>
       <duration>7200</duration>
       <radio>0</radio>
@@ -815,9 +824,11 @@
       <url></url>
       <directory>/Directory1/SubDirectory1/</directory>
       <channelname>Demo TV Channel 2</channelname>
+      <episodetitle>Demo TV Recording entry 12 Episode Name</episodetitle>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</plot>
       <genretype>10</genretype>
+      <episode>3</episode>
       <genresubtype>0</genresubtype>
       <time>14:00</time>
       <duration>7500</duration>
@@ -828,6 +839,7 @@
       <url></url>
       <directory>/Directory1/SubDirectory1/</directory>
       <channelname>Demo TV Channel 3</channelname>
+      <episodetitle>Demo TV Recording entry 13 Episode Name</episodetitle>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</plot>
       <genretype>10</genretype>

--- a/pvr.demo/addon.xml.in
+++ b/pvr.demo/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.demo"
-  version="3.5.0"
+  version="3.5.1"
   name="PVR Demo Client"
   provider-name="Pulse-Eight Ltd., Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/PVRDemoData.cpp
+++ b/src/PVRDemoData.cpp
@@ -268,6 +268,18 @@ bool PVRDemoData::LoadDemoData(void)
       if (XMLUtils::GetString(pRecordingNode, "plotoutline", strTmp))
         recording.strPlotOutline = strTmp;
 
+      /* Episode Name */
+      if (XMLUtils::GetString(pRecordingNode, "episodetitle", strTmp))
+        recording.strEpisodeName = strTmp;
+
+      /* Series Number */
+      if (!XMLUtils::GetInt(pRecordingNode, "series", recording.iSeriesNumber))
+        recording.iSeriesNumber = 0;
+
+      /* Episode Number */
+      if (!XMLUtils::GetInt(pRecordingNode, "episode", recording.iEpisodeNumber))
+        recording.iEpisodeNumber = 0;
+
       /* genre type */
       XMLUtils::GetInt(pRecordingNode, "genretype", recording.iGenreType);
 
@@ -341,6 +353,18 @@ bool PVRDemoData::LoadDemoData(void)
       /* plot outline */
       if (XMLUtils::GetString(pRecordingNode, "plotoutline", strTmp))
         recording.strPlotOutline = strTmp;
+
+      /* Episode Name */
+      if (XMLUtils::GetString(pRecordingNode, "episodetitle", strTmp))
+        recording.strEpisodeName = strTmp;
+
+      /* Series Number */
+      if (!XMLUtils::GetInt(pRecordingNode, "series", recording.iSeriesNumber))
+        recording.iSeriesNumber = 0;
+
+      /* Episode Number */
+      if (!XMLUtils::GetInt(pRecordingNode, "episode", recording.iEpisodeNumber))
+        recording.iEpisodeNumber = 0;
 
       /* genre type */
       XMLUtils::GetInt(pRecordingNode, "genretype", recording.iGenreType);
@@ -617,6 +641,8 @@ PVR_ERROR PVRDemoData::GetRecordings(ADDON_HANDLE handle, bool bDeleted)
     xbmcRecording.iGenreType    = recording.iGenreType;
     xbmcRecording.iGenreSubType = recording.iGenreSubType;
     xbmcRecording.recordingTime = recording.recordingTime;
+    xbmcRecording.iEpisodeNumber = recording.iEpisodeNumber;
+    xbmcRecording.iSeriesNumber = recording.iSeriesNumber;
     xbmcRecording.bIsDeleted    = bDeleted;
     xbmcRecording.channelType   = recording.bRadio ? PVR_RECORDING_CHANNEL_TYPE_RADIO : PVR_RECORDING_CHANNEL_TYPE_TV;
 
@@ -625,6 +651,7 @@ PVR_ERROR PVRDemoData::GetRecordings(ADDON_HANDLE handle, bool bDeleted)
     strncpy(xbmcRecording.strPlot,        recording.strPlot.c_str(),        sizeof(xbmcRecording.strPlot) - 1);
     strncpy(xbmcRecording.strRecordingId, recording.strRecordingId.c_str(), sizeof(xbmcRecording.strRecordingId) - 1);
     strncpy(xbmcRecording.strTitle,       recording.strTitle.c_str(),       sizeof(xbmcRecording.strTitle) - 1);
+    strncpy(xbmcRecording.strEpisodeName, recording.strEpisodeName.c_str(), sizeof(xbmcRecording.strEpisodeName) - 1);
     strncpy(xbmcRecording.strDirectory,   recording.strDirectory.c_str(),   sizeof(xbmcRecording.strDirectory) - 1);
 
     /* TODO: PVR API 5.0.0: Implement this */

--- a/src/PVRDemoData.h
+++ b/src/PVRDemoData.h
@@ -65,12 +65,15 @@ struct PVRDemoRecording
   int         iDuration;
   int         iGenreType;
   int         iGenreSubType;
+  int         iSeriesNumber;
+  int         iEpisodeNumber;
   std::string strChannelName;
   std::string strPlotOutline;
   std::string strPlot;
   std::string strRecordingId;
   std::string strStreamURL;
   std::string strTitle;
+  std::string strEpisodeName;
   std::string strDirectory;
   time_t      recordingTime;
 };


### PR DESCRIPTION
Recordings now can be given Episode/Season numbering as well as Episode Title.

Wanted to check if recordings show the changes that relate to https://github.com/xbmc/xbmc/pull/13300
Good news is they do, bad news is i think ive found a bug, but im not sure exactly where its coming from. Ill throw up an issue on here with screenshots and details in a minute