### PR TITLE
Fix icon path since moved to repo

### DIFF
--- a/pvr.demo/PVRDemoAddonSettings.xml
+++ b/pvr.demo/PVRDemoAddonSettings.xml
@@ -6,7 +6,7 @@
       <radio>0</radio>
       <number>1</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/01.png</icon>
+      <icon>data/01.png</icon>
       <stream>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</stream>
     </channel>
     <channel>
@@ -14,7 +14,7 @@
       <radio>0</radio>
       <number>2</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/02.png</icon>
+      <icon>data/02.png</icon>
       <stream>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</stream>
     </channel>
     <channel>
@@ -22,7 +22,7 @@
       <radio>0</radio>
       <number>3</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/03.png</icon>
+      <icon>data/03.png</icon>
       <stream>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</stream>
     </channel>
     <channel>
@@ -30,7 +30,7 @@
       <radio>0</radio>
       <number>4</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/04.png</icon>
+      <icon>data/04.png</icon>
       <stream>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</stream>
     </channel>
     <channel>
@@ -38,7 +38,7 @@
       <radio>0</radio>
       <number>5</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/05.png</icon>
+      <icon>data/05.png</icon>
       <stream>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</stream>
     </channel>
     <channel>
@@ -46,7 +46,7 @@
       <radio>0</radio>
       <number>6</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/06.png</icon>
+      <icon>data/06.png</icon>
       <stream>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</stream>
     </channel>
     <channel>
@@ -54,7 +54,7 @@
       <radio>0</radio>
       <number>7</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/07.png</icon>
+      <icon>data/07.png</icon>
       <stream>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</stream>
     </channel>
     <channel>
@@ -62,7 +62,7 @@
       <radio>0</radio>
       <number>8</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/08.png</icon>
+      <icon>data/08.png</icon>
       <stream>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</stream>
     </channel>
     <channel>
@@ -70,7 +70,7 @@
       <radio>0</radio>
       <number>9</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/09.png</icon>
+      <icon>data/09.png</icon>
       <stream>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</stream>
     </channel>
     <channel>
@@ -78,7 +78,7 @@
       <radio>0</radio>
       <number>10</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/10.png</icon>
+      <icon>data/10.png</icon>
       <stream>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</stream>
     </channel>
     <channel>
@@ -86,7 +86,7 @@
       <radio>0</radio>
       <number>11</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/11.png</icon>
+      <icon>data/11.png</icon>
       <stream>http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4</stream>
     </channel>
 
@@ -96,7 +96,7 @@
       <radio>1</radio>
       <number>1</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/01.png</icon>
+      <icon>data/01.png</icon>
       <stream></stream>
     </channel>
     <channel>
@@ -104,7 +104,7 @@
       <radio>1</radio>
       <number>2</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/02.png</icon>
+      <icon>data/02.png</icon>
       <stream></stream>
     </channel>
     <channel>
@@ -112,7 +112,7 @@
       <radio>1</radio>
       <number>3</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/03.png</icon>
+      <icon>data/03.png</icon>
       <stream></stream>
     </channel>
     <channel>
@@ -120,7 +120,7 @@
       <radio>1</radio>
       <number>4</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/04.png</icon>
+      <icon>data/04.png</icon>
       <stream></stream>
     </channel>
     <channel>
@@ -128,7 +128,7 @@
       <radio>1</radio>
       <number>5</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/05.png</icon>
+      <icon>data/05.png</icon>
       <stream></stream>
     </channel>
     <channel>
@@ -136,7 +136,7 @@
       <radio>1</radio>
       <number>6</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/06.png</icon>
+      <icon>data/06.png</icon>
       <stream></stream>
     </channel>
     <channel>
@@ -144,7 +144,7 @@
       <radio>1</radio>
       <number>7</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/07.png</icon>
+      <icon>data/07.png</icon>
       <stream></stream>
     </channel>
     <channel>
@@ -152,7 +152,7 @@
       <radio>1</radio>
       <number>8</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/08.png</icon>
+      <icon>data/08.png</icon>
       <stream></stream>
     </channel>
     <channel>
@@ -160,7 +160,7 @@
       <radio>1</radio>
       <number>9</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/09.png</icon>
+      <icon>data/09.png</icon>
       <stream></stream>
     </channel>
     <channel>
@@ -168,7 +168,7 @@
       <radio>1</radio>
       <number>10</number>
       <encryption>0</encryption>
-      <icon>special://xbmc/addons/pvr.demo/data/10.png</icon>
+      <icon>data/10.png</icon>
       <stream></stream>
     </channel>
 
@@ -203,9 +203,9 @@
   </channels>
   <channelgroups>
     <!--
-      !!IMPORTANT!! 
-      The channel member mapping is done by the internal channel id, 
-      not by the channel number you specified in the channel element. 
+      !!IMPORTANT!!
+      The channel member mapping is done by the internal channel id,
+      not by the channel number you specified in the channel element.
       The internal channel id starts by 1 for the first channel element
       and becomes increased by 1 for each channel element.
     -->

--- a/src/PVRDemoData.cpp
+++ b/src/PVRDemoData.cpp
@@ -106,7 +106,7 @@ bool PVRDemoData::LoadDemoData(void)
       if (!XMLUtils::GetString(pChannelNode, "icon", strTmp))
         channel.strIconPath = m_strDefaultIcon;
       else
-        channel.strIconPath = strTmp;
+        channel.strIconPath = g_strClientPath + strTmp;
 
       /* stream url */
       if (!XMLUtils::GetString(pChannelNode, "stream", strTmp))
@@ -137,7 +137,7 @@ bool PVRDemoData::LoadDemoData(void)
 
       /* radio/TV */
       XMLUtils::GetBoolean(pGroupNode, "radio", group.bRadio);
-      
+
       /* sort position */
       XMLUtils::GetInt(pGroupNode, "position", group.iPosition);
 


### PR DESCRIPTION
Path to icons is for old location when it was installed using Kodi installer.

Is the same for matrix version but I can do another PR if that is helpful.

EDIT: Just noticed I removed some whitespace  cause my text editor does that automatically.

I can remove that change if it is not wanted.