### PR TITLE
separate xml data scan to own functions

### DIFF
--- a/pvr.demo/addon.xml.in
+++ b/pvr.demo/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.demo"
-  version="4.0.0"
+  version="4.0.1"
   name="PVR Demo Client"
   provider-name="Pulse-Eight Ltd., Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/PVRDemoData.h
+++ b/src/PVRDemoData.h
@@ -24,6 +24,8 @@
 #include "p8-platform/os.h"
 #include "client.h"
 
+class TiXmlNode;
+
 struct PVRDemoEpgEntry
 {
   int         iBroadcastId;
@@ -123,6 +125,12 @@ public:
 protected:
   bool LoadDemoData(void);
 private:
+  bool ScanXMLChannelData(const TiXmlNode* pChannelNode, int iUniqueChannelId, PVRDemoChannel& channel);
+  bool ScanXMLChannelGroupData(const TiXmlNode* pGroupNode, int iUniqueGroupId, PVRDemoChannelGroup& group);
+  bool ScanXMLEpgData(const TiXmlNode* pEpgNode);
+  bool ScanXMLRecordingData(const TiXmlNode* pRecordingNode, int iUniqueGroupId, PVRDemoRecording& recording);
+  bool ScanXMLTimerData(const TiXmlNode* pTimerNode, PVRDemoTimer& timer);
+
   std::vector<PVRDemoChannelGroup> m_groups;
   std::vector<PVRDemoChannel>      m_channels;
   std::vector<PVRDemoRecording>    m_recordings;


### PR DESCRIPTION
This change is related to issue https://github.com/kodi-pvr/pvr.demo/issues/60 and cleanup the xml load in cpp.

Here is it separated to own functions, where use one time the same function for the both recording types and also the others to have more clean and if in future maybe another type e.g. for channel must be checked.