### PR TITLE
4.1.1: Fix unitialized PVR_RECORDING struct in GetRecordings. Get rid…

### DIFF
--- a/pvr.demo/addon.xml.in
+++ b/pvr.demo/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.demo"
-  version="4.1.0"
+  version="4.1.1"
   name="PVR Demo Client"
   provider-name="Pulse-Eight Ltd., Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/PVRDemoData.cpp
+++ b/src/PVRDemoData.cpp
@@ -163,8 +163,7 @@ PVR_ERROR PVRDemoData::GetChannels(ADDON_HANDLE handle, bool bRadio)
   {
     if (channel.bRadio == bRadio)
     {
-      PVR_CHANNEL xbmcChannel;
-      memset(&xbmcChannel, 0, sizeof(PVR_CHANNEL));
+      PVR_CHANNEL xbmcChannel = {};
 
       xbmcChannel.iUniqueId         = channel.iUniqueId;
       xbmcChannel.bIsRadio          = channel.bRadio;
@@ -216,8 +215,7 @@ PVR_ERROR PVRDemoData::GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
     PVRDemoChannelGroup &group = m_groups.at(iGroupPtr);
     if (group.bRadio == bRadio)
     {
-      PVR_CHANNEL_GROUP xbmcGroup;
-      memset(&xbmcGroup, 0, sizeof(PVR_CHANNEL_GROUP));
+      PVR_CHANNEL_GROUP xbmcGroup = {};
 
       xbmcGroup.bIsRadio = bRadio;
       xbmcGroup.iPosition = group.iPosition;
@@ -243,8 +241,7 @@ PVR_ERROR PVRDemoData::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHA
         if (iId < 0 || iId > (int)m_channels.size() - 1)
           continue;
         PVRDemoChannel &channel = m_channels.at(iId);
-        PVR_CHANNEL_GROUP_MEMBER xbmcGroupMember;
-        memset(&xbmcGroupMember, 0, sizeof(PVR_CHANNEL_GROUP_MEMBER));
+        PVR_CHANNEL_GROUP_MEMBER xbmcGroupMember = {};
 
         strncpy(xbmcGroupMember.strGroupName, group.strGroupName, sizeof(xbmcGroupMember.strGroupName) - 1);
         xbmcGroupMember.iChannelUniqueId  = channel.iUniqueId;
@@ -280,8 +277,7 @@ PVR_ERROR PVRDemoData::GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, ti
       {
         PVRDemoEpgEntry &myTag = myChannel.epg.at(iEntryPtr);
 
-        EPG_TAG tag;
-        memset(&tag, 0, sizeof(EPG_TAG));
+        EPG_TAG tag = {};
 
         tag.iUniqueBroadcastId = myTag.iBroadcastId + iAddBroadcastId;
         tag.iUniqueChannelId   = iChannelUid;
@@ -324,7 +320,7 @@ PVR_ERROR PVRDemoData::GetRecordings(ADDON_HANDLE handle, bool bDeleted)
   {
     PVRDemoRecording &recording = *it;
 
-    PVR_RECORDING xbmcRecording;
+    PVR_RECORDING xbmcRecording = {};
 
     xbmcRecording.iDuration     = recording.iDuration;
     xbmcRecording.iGenreType    = recording.iGenreType;
@@ -377,8 +373,7 @@ PVR_ERROR PVRDemoData::GetTimers(ADDON_HANDLE handle)
   {
     PVRDemoTimer &timer = *it;
 
-    PVR_TIMER xbmcTimer;
-    memset(&xbmcTimer, 0, sizeof(PVR_TIMER));
+    PVR_TIMER xbmcTimer = {};
 
     /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
     xbmcTimer.iTimerType = PVR_TIMER_TYPE_NONE;


### PR DESCRIPTION
… of memset; instead use {} to init structs.

Stumbled over funny "year" values for recordings, caused by uninitialized `PVR_RECORDING` struct members:

![screenshot003](https://user-images.githubusercontent.com/3226626/66900392-03248480-effd-11e9-896b-f8487fea7edf.png)
