### PR TITLE
Fixed GetChannelGroupMembers off-by-one error

### DIFF
--- a/pvr.demo/addon.xml.in
+++ b/pvr.demo/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.demo"
-  version="20.4.1"
+  version="20.4.2"
   name="Demo PVR Client"
   provider-name="Pulse-Eight Ltd., Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.demo/changelog.txt
+++ b/pvr.demo/changelog.txt
@@ -1,3 +1,6 @@
+v20.4.2
+- Fixed GetChannelGroupMembers
+
 v20.4.1
 - Change name to make add-on easier to find in UI
 

--- a/src/PVRDemo.cpp
+++ b/src/PVRDemo.cpp
@@ -265,12 +265,15 @@ PVR_ERROR CPVRDemo::GetChannelGroupMembers(const kodi::addon::PVRChannelGroup& g
   {
     if (myGroup.strGroupName == group.GetGroupName())
     {
-      for (const auto& iId : myGroup.members)
+      for (int iId : myGroup.members)
       {
-        if (iId < 0 || iId > (int)m_channels.size() - 1)
+        if (iId < 1 || iId > static_cast<int>(m_channels.size()))
+        {
+          kodi::Log(ADDON_LOG_ERROR, "ignoring invalid channel id '%d')", iId);
           continue;
+        }
 
-        PVRDemoChannel& channel = m_channels.at(iId);
+        PVRDemoChannel& channel = m_channels.at(iId - 1);
         kodi::addon::PVRChannelGroupMember kodiGroupMember;
         kodiGroupMember.SetGroupName(group.GetGroupName());
         kodiGroupMember.SetChannelUniqueId(channel.iUniqueId);


### PR DESCRIPTION
Bug revealed by log-spam on each Kodi startup.

```log
2022-01-03 12:42:38.226471+0100 kodi.bin[94306:6986029] 2022-01-03 12:42:38.226 T:6986029   ERROR <general>: operator(): Cannot find group 'TV Group #1' or channel '14'
2022-01-03 13:06:02.131181+0100 kodi.bin[94306:6986029] 2022-01-03 13:06:02.131 T:6986029   ERROR <general>: operator(): Cannot find group 'TV Group #2' or channel '14'
```

@phunkyfish whenever you find time for a review.