### PR TITLE
Add missing fields for testing

### DIFF
--- a/pvr.demo/PVRDemoAddonSettings.xml
+++ b/pvr.demo/PVRDemoAddonSettings.xml
@@ -343,7 +343,7 @@
       <episode>1</episode>
       <episodetitle>Demo EPG entry 1 Episode Title</episodetitle>
       <icon></icon>
-      <genretype>16</genretype>
+      <genretype>96</genretype>
       <genresubtype>0</genresubtype>
     </entry>
     <entry>
@@ -401,14 +401,15 @@
     </entry>
     <entry>
       <broadcastid>600</broadcastid>
-      <title>Demo EPG entry 6</title>
+      <title>Demo EPG movie entry 6</title>
       <channelid>6</channelid>
       <start>0</start>
       <end>3900</end>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed. </plot>
       <icon></icon>
-      <genretype>96</genretype>
+      <year>2024</year>
+      <genretype>16</genretype>
       <genresubtype>0</genresubtype>
     </entry>
     <entry>
@@ -432,6 +433,9 @@
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed. </plot>
       <icon></icon>
+      <episode>2</episode>
+      <episodepart>4</episodepart>
+      <episodetitle>Demo EPG entry 8 Episode Part Title</episodetitle>
       <genretype>128</genretype>
       <genresubtype>0</genresubtype>
     </entry>
@@ -587,7 +591,7 @@
       <title>Demo TV Recording entry 1</title>
       <episodetitle>Demo TV Recording 1 Episode Name</episodetitle>
       <url>https://mirrors.kodi.tv/demo-files/BBB/bbb_sunflower_1080p_30fps_normal.mp4</url>
-      <directory>/Directory1/SubDirectory1/</directory>
+      <directory>/Directory1/TV Shows/</directory>
       <channelname>Demo TV Channel 1</channelname>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</plot>
@@ -605,7 +609,7 @@
       <title>Demo TV Recording entry 2</title>
       <episodetitle>Demo TV Recording 2 Episode Name</episodetitle>
       <url>https://mirrors.kodi.tv/demo-files/BBB/bbb_sunflower_1080p_30fps_normal.mp4</url>
-      <directory>/Directory1/SubDirectory1/</directory>
+      <directory>/Directory1/TV Shows/</directory>
       <channelname>Demo TV Channel 2</channelname>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</plot>
@@ -720,12 +724,13 @@
     <recording>
       <title>Demo TV Recording entry 10</title>
       <url>https://mirrors.kodi.tv/demo-files/BBB/bbb_sunflower_1080p_30fps_normal.mp4</url>
-      <directory>/Directory3/</directory>
+      <directory>/Directory1/Movies/</directory>
       <channelname>Demo TV Channel 10</channelname>
       <plotoutline>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</plotoutline>
       <plot>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</plot>
-      <genretype>10</genretype>
+      <genretype>16</genretype>
       <genresubtype>0</genresubtype>
+      <year>2024</year>
       <time>14:00</time>
       <duration>7500</duration>
       <radio>0</radio>

--- a/pvr.demo/addon.xml.in
+++ b/pvr.demo/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.demo"
-  version="21.0.1"
+  version="21.1.0"
   name="Demo PVR Client"
   provider-name="Pulse-Eight Ltd., Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.demo/changelog.txt
+++ b/pvr.demo/changelog.txt
@@ -1,3 +1,7 @@
+v21.1.0
+- add SetEpisodePartNumber() to EPG
+- add SetYear() to Recordings and EPG
+
 v21.0.1
 - Translations updates from Weblate
 	- ast_es, de_de, es_es, et_ee, fi_fi, fr_fr, hr_hr, it_it, ru_ru, zh_cn
@@ -47,4 +51,3 @@ v7.1.5
 v7.1.4
 Translations updates from Weblate
 	- af_za, am_et, ar_sa, az_az, be_by, bg_bg, bs_ba, ca_es, cs_cz, cy_gb, da_dk, de_de, el_gr, en_au, en_nz, en_us, eo, es_ar, es_es, es_mx, et_ee, eu_es, fa_af, fa_ir, fi_fi, fo_fo, fr_ca, fr_fr, gl_es, he_il, hi_in, hr_hr, hu_hu, hy_am, id_id, is_is, it_it, ja_jp, ko_kr, lt_lt, lv_lv, mi, mk_mk, ml_in, mn_mn, ms_my, mt_mt, my_mm, nb_no, nl_nl, pl_pl, pt_br, pt_pt, ro_ro, ru_ru, si_lk, sk_sk, sl_si, sq_al, sr_rs, sr_rs@latin, sv_se, szl, ta_in, te_in, tg_tj, th_th, tr_tr, uk_ua, uz_uz, vi_vn, zh_cn, zh_tw
-

--- a/src/PVRDemo.cpp
+++ b/src/PVRDemo.cpp
@@ -125,6 +125,8 @@ PVR_ERROR CPVRDemo::GetEPGForChannel(int channelUid,
         tag.SetSeriesNumber(myTag.iSeriesNumber);
         tag.SetEpisodeNumber(myTag.iEpisodeNumber);
         tag.SetEpisodeName(myTag.strEpisodeName);
+        tag.SetEpisodePartNumber(myTag.iEpisodePartNumber);
+        tag.SetYear(myTag.iYear);
 
         iLastEndTimeTmp = tag.GetEndTime();
 
@@ -324,6 +326,7 @@ PVR_ERROR CPVRDemo::GetRecordings(bool deleted, kodi::addon::PVRRecordingsResult
     kodiRecording.SetTitle(recording.strTitle);
     kodiRecording.SetEpisodeName(recording.strEpisodeName);
     kodiRecording.SetDirectory(recording.strDirectory);
+    kodiRecording.SetYear(recording.iYear);
 
     /* TODO: PVR API 5.0.0: Implement this */
     kodiRecording.SetChannelUid(recording.iChannelId);
@@ -770,6 +773,14 @@ bool CPVRDemo::ScanXMLEpgData(const XMLNode* pEpgNode)
   /* genre subtype */
   XMLGetInt(pEpgNode, "genresubtype", entry.iGenreSubType);
 
+  /* episodepart */
+  if (!XMLGetInt(pEpgNode, "episodepart", entry.iEpisodePartNumber))
+    entry.iEpisodePartNumber = EPG_TAG_INVALID_SERIES_EPISODE;
+
+  /* year */
+  if (!XMLGetInt(pEpgNode, "year", entry.iYear))
+    entry.iYear = 0;
+
   kodi::Log(ADDON_LOG_DEBUG, "loaded EPG entry '%s' channel '%d' start '%d' end '%d'",
             entry.strTitle.c_str(), entry.iChannelId, entry.startTime, entry.endTime);
 
@@ -861,6 +872,9 @@ bool CPVRDemo::ScanXMLRecordingData(const XMLNode* pRecordingNode,
   recording.iProviderId = PVR_PROVIDER_INVALID_UID;
   XMLGetInt(pRecordingNode, "provider", recording.iProviderId);
 
+  /* recording year */
+  if (!XMLGetInt(pRecordingNode, "year", recording.iYear))
+    recording.iYear = 0;
   return true;
 }
 

--- a/src/PVRDemo.h
+++ b/src/PVRDemo.h
@@ -29,8 +29,9 @@ struct PVRDemoEpgEntry
   //  bool bNotify;
   int iSeriesNumber;
   int iEpisodeNumber;
-  //  int iEpisodePartNumber;
+  int iEpisodePartNumber;
   std::string strEpisodeName;
+  int iYear;
 };
 
 struct PVRDemoChannel
@@ -67,6 +68,7 @@ struct PVRDemoRecording
   time_t recordingTime;
   int iChannelId;
   int iProviderId;
+  int iYear;
 };
 
 struct PVRDemoTimer


### PR DESCRIPTION
To assist testing without a backend, add SetYear() to Recordings and EPG  and add SetEpisodePartNumber() to EPG.  

Note currently EpisodePartNumber is not exposed for skinnning.